### PR TITLE
feat: Added blueprint admin

### DIFF
--- a/nginx.nix
+++ b/nginx.nix
@@ -17,6 +17,15 @@ in
 			extraConfig = authelia-extras.authelia-auth;
 		};
 	};
+	services.nginx.virtualHosts."admin.api.sitblueprint.com" = {
+		forceSSL = true;
+		enableACME = true;
+		extraConfig = authelia-extras.authelia-location;
+		locations."/" = {
+			proxyPass = "http://10.10.1.2:8081";
+			extraConfig = authelia-extras.authelia-auth;
+		};
+	};
 	services.nginx.virtualHosts."admin.sitblueprint.com" = {
 		forceSSL = true;
 		enableACME = true;


### PR DESCRIPTION
## Description
Added blueprint admin. I will probably have to update the `docker-compose` of the `Blueprint Admin API` to map to port `8081` instead of `8080` to match the nginx config.